### PR TITLE
bug fixed: findDegreeByTime

### DIFF
--- a/src/Chart.cpp
+++ b/src/Chart.cpp
@@ -215,6 +215,12 @@ double Chart::findDegreeByTime(const double time) const {
 				a2 += 180;
 			}
 		}
+
+		if ((a1 <= 0.0 && a2 >= 0.0) || (a1 >= 0.0 && a2 <= 0.0) || (a1 <= 360.0 && a2 >= 360.0) || (a1 >= 360.0 && a2 <= 360.0)){
+			result = fmod(result, 360);
+			return result;
+        }
+	
 		result = getYfromX(a1, a2, c1/100, c2/100, (d - d1) / (d2 - d1));
 		result = fmod(result, 180);
 	}


### PR DESCRIPTION
原來的程式在獲取譜面GALACTIC WARZONE中間那個跨越0°線的正弦波表演時fmod會把345°變成165°等，導致角度獲取的並不是-15°/345°。初步修改方案是在判斷跨過0°線時返回fmod 360而不是180。該方案還未經過詳細測試，僅作為解決方案參考。